### PR TITLE
Fixed UI to stop giving drms ExportError

### DIFF
--- a/downloader_ui.py
+++ b/downloader_ui.py
@@ -84,7 +84,7 @@ def choose_spikes():
 def main():
     st.title("HITS SDO Downloader")
     st.write("This app downloads HMI Intensitygram and Magnetogram images from the SDO website.")
-    path = os.path.join('/Users/dgeyfman/Documents/VSCodeProjects/hits-sdo-downloader/data2')
+    path = os.path.join(os.getcwd(), 'data2')
     download_limit = get_limit()
     # Get user input
     start_date, end_date = get_date_range()

--- a/downloader_ui.py
+++ b/downloader_ui.py
@@ -84,12 +84,13 @@ def choose_spikes():
 def main():
     st.title("HITS SDO Downloader")
     st.write("This app downloads HMI Intensitygram and Magnetogram images from the SDO website.")
-    path = os.path.join(os.getcwd(), 'data2')
+    path = os.path.join('/Users/dgeyfman/Documents/VSCodeProjects/hits-sdo-downloader/data2')
     download_limit = get_limit()
     # Get user input
     start_date, end_date = get_date_range()
     email = get_email()
-    wavelength = get_wavelength()
+    # int() is used because the UI returns a string by default
+    wavelength = int(get_wavelength())
     file_format = get_file_type()
     instrument = get_instrument()
     cadence = choose_cadence()
@@ -102,7 +103,7 @@ def main():
     so=st.empty()
     with rd.stdout(to=so):
         if run_button:
-            downloader = Downloader(email, start_date, end_date, wavelength, instrument, cadence, file_format, path, download_limit, get_spike)
+            downloader = Downloader(email, start_date, end_date, [wavelength], instrument, cadence, file_format, path, download_limit, get_spike)
     
             st.write("💪😎 We be balling 🏀⛹️")
 
@@ -115,7 +116,7 @@ def main():
                     break
 
             if not is_larger:
-                downloader.download_data()        
+                downloader.download_data()
 
 
     # https://discuss.streamlit.io/t/multiple-images-along-the-same-row/118/7


### PR DESCRIPTION
I tried to download the current UI/downloader and run it on my machine. The UI kept giving a drms ExportError, which after looking through the code I found out to be caused by conflicts between streamlit and the downloader. After fixing up the downloader and the UI a little bit, I resolved the issue. The downloader UI is fully functional for me now.